### PR TITLE
HKDF support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,20 +98,11 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f56c476256dc249def911d6f7580b5fc7e875895b5d7ee88f5d602208035744"
+checksum = "743ad5a418686aad3b87fd14c43badd828cf26e214a00f92a384291cf22e1811"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "anomaly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c7f9e6187c92c6c166ba8cca80b9782e61e3bb34f25a6374d279014535b76e6"
-dependencies = [
- "backtrace",
 ]
 
 [[package]]
@@ -221,9 +212,9 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byteorder"
-version = "1.3.2"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
+checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "bytes"
@@ -315,11 +306,11 @@ dependencies = [
 
 [[package]]
 name = "cryptouri"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628b8531cbcd746cf229179ace71f4fa6437ab3be74410d80470a966e4435b5a"
+checksum = "5407851d296206878edcd1860c52ffe5d0dc5d311d71c0fc980eec83693fa82b"
 dependencies = [
- "anomaly 0.1.2",
+ "anomaly",
  "secrecy",
  "subtle-encoding",
  "thiserror",
@@ -509,9 +500,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b54058f0a6ff80b6803da8faf8997cde53872b38f4023728f6830b06cd3c0dc"
+checksum = "076f042c5b7b98f31d205f1249267e12a6518c1481e9dae9764af19b707d2292"
 dependencies = [
  "autocfg",
 ]
@@ -868,9 +859,9 @@ checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 
 [[package]]
 name = "regex"
-version = "1.3.3"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5508c1941e4e7cb19965abef075d35a9a8b5cdf0846f30b4050e9b55dc55e87"
+checksum = "322cf97724bea3ee221b78fe25ac9c46114ebb51747ad5babd51a2fc6a8235a8"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -891,9 +882,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.13"
+version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e734e891f5b408a29efbf8309e656876276f49ab6a6ac208600b4419bd893d90"
+checksum = "b28dfe3fe9badec5dbf0a79a9cccad2cfc2ab5484bdb3e44cbd1ae8b3ba2be06"
 
 [[package]]
 name = "remove_dir_all"
@@ -917,7 +908,7 @@ dependencies = [
  "abscissa_core",
  "aead",
  "aes-gcm",
- "anomaly 0.2.0",
+ "anomaly",
  "bytes",
  "chacha20poly1305",
  "chrono",
@@ -1061,9 +1052,9 @@ checksum = "7c65d530b10ccaeac294f349038a597e435b18fb456aadd0840a623f83b9e941"
 
 [[package]]
 name = "subtle-encoding"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc5188a16f729680b6d495b0deaa776944b8e509d24b7f989489b0d8bbcb63b"
+checksum = "7dcb1ed7b8330c5eed5441052651dd7a12c75e2ed88f2ec024ae1fa3a5e59945"
 dependencies = [
  "zeroize",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ anomaly = "0.2"
 bytes = "0.5"
 chacha20poly1305 = "0.3"
 chrono = "0.4"
-cryptouri = "0.3"
+cryptouri = "0.4"
 gumdrop = { version = "0.7", optional = true }
 getrandom = "0.1"
 hkdf = "0.8"

--- a/src/bin/sear/op/create.rs
+++ b/src/bin/sear/op/create.rs
@@ -71,14 +71,10 @@ impl CreateOp {
         assert!(!self.preserve_pathnames, "-P option unsupported");
         assert!(!self.preserve_permissions, "-p option unsupported");
 
-        let symmetric_key = self
-            .keyring
-            .symmetric_key()
-            .unwrap_or_else(|| {
-                status_err!("no symmetric key selected (use -K flag)");
-                exit(1);
-            })
-            .clone();
+        let symmetric_key = self.keyring.symmetric_key().unwrap_or_else(|| {
+            status_err!("no symmetric key selected (use -K flag)");
+            exit(1);
+        });
 
         let archive = File::create(&self.archive)?;
 

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,7 +1,5 @@
 //! Cryptography functionality
-//!
-//! WARNING: This functionality is unfinished and subject to change.
-//! It should not be considered ready for production use.
 
+pub mod kdf;
 pub mod stream;
 pub mod symmetric;

--- a/src/crypto/kdf.rs
+++ b/src/crypto/kdf.rs
@@ -1,0 +1,77 @@
+//! Key derivation functionality
+
+use super::symmetric;
+use crate::{
+    builder::MAGIC_BYTES,
+    error::{Error, ErrorKind},
+};
+use aead::{generic_array::GenericArray, NewAead};
+use aes_gcm::Aes256Gcm;
+use anomaly::{fail, format_err};
+use chacha20poly1305::ChaCha20Poly1305;
+use cryptouri::{
+    secret_key::{self, ExposeSecret, HkdfSha256Key},
+    CryptoUri,
+};
+use hkdf::Hkdf;
+use sha2::Sha256;
+use std::fmt::{self, Debug};
+
+/// Key derivation algorithm configured with input key material
+// TODO(tarcieri): support for other KDFs besides HKDF-SHA-256?
+pub struct Key(HkdfSha256Key);
+
+impl Key {
+    /// Parse an HKDF key from a CryptoURI
+    pub fn parse_uri(key_str: &str) -> Result<Self, Error> {
+        let key_uri = CryptoUri::parse_uri(key_str.trim_end())
+            .map_err(|_e| format_err!(ErrorKind::Parse, "invalid CryptoURI"))?;
+
+        let secret_key = key_uri
+            .secret_key()
+            .ok_or_else(|| format_err!(ErrorKind::Parse, "expected a crypto:sec:key"))?;
+
+        let hkdf_key = secret_key
+            .hkdfsha256_key()
+            .ok_or_else(|| format_err!(ErrorKind::Parse, "expected a crypto:sec:key:hkdfsha256"))?;
+
+        match hkdf_key.derived_alg() {
+            Some(secret_key::Algorithm::Aes256Gcm)
+            | Some(secret_key::Algorithm::ChaCha20Poly1305) => (),
+            _ => fail!(
+                ErrorKind::Parse,
+                "key type must be hkdfsha256+aes256gcm or hkdfsha256+chacha20poly1305"
+            ),
+        }
+
+        Ok(Key(hkdf_key.clone()))
+    }
+
+    /// Derive a symmetric key using HKDF
+    pub fn derive_symmetric_key(&self, salt: impl AsRef<[u8]>) -> symmetric::Key {
+        let mut derived_key = GenericArray::default();
+        Hkdf::<Sha256>::new(Some(salt.as_ref()), self.0.expose_secret())
+            .expand(MAGIC_BYTES, &mut derived_key)
+            .expect("HKDF expand failed!");
+
+        match self.0.derived_alg() {
+            Some(secret_key::Algorithm::Aes256Gcm) => {
+                symmetric::Key::Aes256Gcm(Box::new(Aes256Gcm::new(derived_key)))
+            }
+            Some(secret_key::Algorithm::ChaCha20Poly1305) => {
+                symmetric::Key::ChaCha20Poly1305(Box::new(ChaCha20Poly1305::new(derived_key)))
+            }
+            _ => unreachable!(), // Checked above in `Key::parse_uri`
+        }
+    }
+}
+
+impl Debug for Key {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        writeln!(
+            f,
+            "kdf::Key {{ derived_alg: {}, .. }}",
+            self.0.derived_alg().unwrap()
+        )
+    }
+}

--- a/src/crypto/stream/writer.rs
+++ b/src/crypto/stream/writer.rs
@@ -57,7 +57,7 @@ impl<W: io::Write> Writer<W> {
         aad: impl Into<Vec<u8>>,
         chunk_size: ChunkSize,
     ) -> Self {
-        // TODO(tarcieri): derive unique symmetric key and nonce prefix using HKDF
+        // TODO(tarcieri): use randomized or derived (e.g. via HKDF) nonce?
         let nonce_prefix = Default::default();
 
         // Allocate the buffer with the chunk length + tag overhead,

--- a/src/crypto/symmetric.rs
+++ b/src/crypto/symmetric.rs
@@ -43,8 +43,8 @@ impl Key {
 impl Debug for Key {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         f.write_str(match self {
-            Key::Aes256Gcm(_) => "Key::Aes256Gcm {{ .. }}",
-            Key::ChaCha20Poly1305(_) => "Key::ChaCha20Poly1305 {{ .. }}",
+            Key::Aes256Gcm(_) => "symmetric::Key::Aes256Gcm {{ .. }}",
+            Key::ChaCha20Poly1305(_) => "symmetric::Key::ChaCha20Poly1305 {{ .. }}",
         })
     }
 }

--- a/tests/fixtures/keys/encryption.key
+++ b/tests/fixtures/keys/encryption.key
@@ -1,1 +1,1 @@
-crypto:sec:key:aes256gcm:k5k9qk3h678d5hwnfusvyf2qagd4393ulrjmlrl6shulyjf9qk6qh0amxk
+crypto:sec:key:hkdfsha256+aes256gcm:pv9skzctpv9skzctpv9skzctpv9skzctpv9skzctpv9skzctpv9sxm0sk0


### PR DESCRIPTION
Switches the symmetric key format to:

    crypto:sec:key:hkdfsha256+aes256gcm

(or `hkdfsha256+chacha20poly1305`)

Uses HKDF-SHA-256 to derive a unique symmetric key per file as a combination of input key material and a randomly generated UUID (included in the header of every archive)